### PR TITLE
mod: update Go mod file to point to the remote module on GitHub

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,4 @@ module github.com/fermyon/spin-favicon
 
 go 1.17
 
-require github.com/fermyon/spin/sdk/go v0.0.0
-
-replace github.com/fermyon/spin/sdk/go v0.0.0 => ../../Rust/spin/sdk/go/
+require github.com/fermyon/spin/sdk/go v0.0.0-20220330104215-9ade2c81adb9

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/fermyon/spin/sdk/go v0.0.0-20220330104215-9ade2c81adb9 h1:9gC7SpJvwUGsz2NSEGZi5zRDsBgHdULKk0BzMu7QkRc=
+github.com/fermyon/spin/sdk/go v0.0.0-20220330104215-9ade2c81adb9/go.mod h1:ARV2oVtnUCykLM+xCBZq8MQrCZddzb3JbeBettYv1S0=


### PR DESCRIPTION
This commit updates `go.mod` to point to the remote module from
GitHub.

While the repository is still private, you might need to:

`go env -w GOPRIVATE=github.com/fermyon/spin && go mod download github.com/fermyon/spin/sdk/go`

Signed-off-by: Radu Matei <radu.matei@fermyon.com>